### PR TITLE
Add address field to EoaExecutorEvent and related structures

### DIFF
--- a/executors/src/eoa/events.rs
+++ b/executors/src/eoa/events.rs
@@ -40,7 +40,7 @@ pub struct EoaSendAttemptNackData {
 pub struct EoaSendAttemptSuccessData {
     #[serde(flatten)]
     pub submitted_transaction: SubmittedTransactionDehydrated,
-    pub address: Address,
+    pub eoa_address: Address,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -78,7 +78,7 @@ impl EoaExecutorEvent {
             payload: SerializableSuccessData {
                 result: EoaSendAttemptSuccessData {
                     submitted_transaction: submitted_transaction.clone(),
-                    address: self.address,
+                    eoa_address: self.address,
                 },
             },
         }

--- a/executors/src/eoa/events.rs
+++ b/executors/src/eoa/events.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use alloy::primitives::Address;
 use serde::{Deserialize, Serialize};
 use twmq::job::RequeuePosition;
 
@@ -16,6 +17,7 @@ use crate::{
 
 pub struct EoaExecutorEvent {
     pub transaction_id: String,
+    pub address: Address,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, thiserror::Error)]
@@ -32,6 +34,13 @@ pub enum EoaConfirmationError {
 pub struct EoaSendAttemptNackData {
     pub nonce: u64,
     pub error: EoaExecutorWorkerError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EoaSendAttemptSuccessData {
+    #[serde(flatten)]
+    pub submitted_transaction: SubmittedTransactionDehydrated,
+    pub address: Address,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,15 +69,17 @@ impl EoaExecutorEvent {
     pub fn send_attempt_success_envelope(
         &self,
         submitted_transaction: SubmittedTransactionDehydrated,
-    ) -> BareWebhookNotificationEnvelope<SerializableSuccessData<SubmittedTransactionDehydrated>>
-    {
+    ) -> BareWebhookNotificationEnvelope<SerializableSuccessData<EoaSendAttemptSuccessData>> {
         BareWebhookNotificationEnvelope {
             transaction_id: self.transaction_id.clone(),
             executor_name: EXECUTOR_NAME.to_string(),
             stage_name: EoaExecutorStage::Send.to_string(),
             event_type: StageEvent::Success,
             payload: SerializableSuccessData {
-                result: submitted_transaction.clone(),
+                result: EoaSendAttemptSuccessData {
+                    submitted_transaction: submitted_transaction.clone(),
+                    address: self.address,
+                },
             },
         }
     }

--- a/executors/src/eoa/store/atomic.rs
+++ b/executors/src/eoa/store/atomic.rs
@@ -535,6 +535,7 @@ impl AtomicEoaExecutorStore {
 
             let event = EoaExecutorEvent {
                 transaction_id: pending_transaction.transaction_id.clone(),
+                address: pending_transaction.user_request.from,
             };
 
             let fail_envelope = event.transaction_failed_envelope(error.clone(), 1);

--- a/executors/src/eoa/store/borrowed.rs
+++ b/executors/src/eoa/store/borrowed.rs
@@ -139,6 +139,7 @@ impl SafeRedisTransaction for ProcessBorrowedTransactions<'_> {
 
                     // Queue webhook event using user_request from SubmissionResult
                     let event = EoaExecutorEvent {
+                        address: result.transaction.user_request.from,
                         transaction_id: transaction_id.to_string(),
                     };
 
@@ -177,6 +178,7 @@ impl SafeRedisTransaction for ProcessBorrowedTransactions<'_> {
                     // Queue webhook event using user_request from SubmissionResult
                     let event = EoaExecutorEvent {
                         transaction_id: transaction_id.to_string(),
+                        address: result.transaction.user_request.from,
                     };
                     let envelope = event.send_attempt_nack_envelope(nonce, err.clone(), 1);
 
@@ -208,6 +210,7 @@ impl SafeRedisTransaction for ProcessBorrowedTransactions<'_> {
                     // Queue webhook event using user_request from SubmissionResult
                     let event = EoaExecutorEvent {
                         transaction_id: transaction_id.to_string(),
+                        address: result.transaction.user_request.from,
                     };
                     let envelope = event.transaction_failed_envelope(err.clone(), 1);
                     if !result.transaction.user_request.webhook_options.is_empty() {

--- a/executors/src/eoa/store/submitted.rs
+++ b/executors/src/eoa/store/submitted.rs
@@ -278,6 +278,7 @@ impl SafeRedisTransaction for CleanSubmittedTransactions<'_> {
                             if !tx.user_request.webhook_options.is_empty() {
                                 let event = EoaExecutorEvent {
                                     transaction_id: tx.transaction_id.clone(),
+                                    address: tx.user_request.from,
                                 };
 
                                 let success_envelope =
@@ -309,6 +310,7 @@ impl SafeRedisTransaction for CleanSubmittedTransactions<'_> {
                             if !tx.user_request.webhook_options.is_empty() {
                                 let event = EoaExecutorEvent {
                                     transaction_id: tx.transaction_id.clone(),
+                                    address: tx.user_request.from,
                                 };
 
                                 let success_envelope =

--- a/executors/src/eoa/worker/confirm.rs
+++ b/executors/src/eoa/worker/confirm.rs
@@ -70,6 +70,7 @@ impl<C: Chain> EoaExecutorWorker<C> {
                     time_since_movement = time_since_movement,
                     stall_timeout = NONCE_STALL_TIMEOUT,
                     current_chain_nonce = current_chain_transaction_count,
+                    cached_transaction_count = cached_transaction_count,
                     "Nonce has been stalled, attempting gas bump"
                 );
 
@@ -85,13 +86,13 @@ impl<C: Chain> EoaExecutorWorker<C> {
                 }
             }
 
-            tracing::debug!("No nonce progress, skipping confirm flow");
-            return Ok(CleanupReport::default());
+            tracing::debug!("No nonce progress, still going ahead with confirm flow");
+            // return Ok(CleanupReport::default());
         }
 
         tracing::info!(
             current_chain_nonce = current_chain_transaction_count,
-            cached_nonce = cached_transaction_count,
+            cached_transaction_count = cached_transaction_count,
             "Processing confirmations"
         );
 
@@ -140,7 +141,7 @@ impl<C: Chain> EoaExecutorWorker<C> {
                 ConfirmedTransaction {
                     transaction_hash: tx.transaction_hash,
                     transaction_id: tx.transaction_id,
-                    receipt: tx.receipt.into(),
+                    receipt: tx.receipt,
                     receipt_serialized: receipt_data,
                 }
             })


### PR DESCRIPTION
- Introduced an `address` field in `EoaExecutorEvent` to capture the user's request address.
- Updated the `EoaSendAttemptSuccessData` structure to include the address.
- Modified event creation in various store implementations to populate the new address field from user requests.
- Enhanced webhook event handling to include address information for better tracking and reporting of transaction outcomes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an address field to various event notifications, providing more detailed information in transaction-related events.

* **Improvements**
  * Enhanced logging with additional nonce and transaction count metrics during transaction confirmation.
  * Confirm flow now proceeds even if no nonce progress is detected, improving reliability of transaction processing.

* **Bug Fixes**
  * Corrected log statements for consistency in variable naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->