### PR TITLE
always fetch latest nonce for 7702 authorizations

### DIFF
--- a/core/src/signer.rs
+++ b/core/src/signer.rs
@@ -194,7 +194,7 @@ pub trait AccountSigner {
         options: Self::SigningOptions,
         chain_id: u64,
         address: Address,
-        nonce: alloy::primitives::U256,
+        nonce: u64,
         credentials: &SigningCredential,
     ) -> impl std::future::Future<Output = Result<SignedAuthorization, EngineError>> + Send;
 }
@@ -355,14 +355,14 @@ impl AccountSigner for EoaSigner {
         options: EoaSigningOptions,
         chain_id: u64,
         address: Address,
-        nonce: U256,
+        nonce: u64,
         credentials: &SigningCredential,
     ) -> Result<SignedAuthorization, EngineError> {
         // Create the Authorization struct that both clients expect
         let authorization = Authorization {
             chain_id: U256::from(chain_id),
             address,
-            nonce: nonce.to::<u64>(),
+            nonce,
         };
         match credentials {
             SigningCredential::Vault(auth_method) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of transaction processing by ensuring the nonce is always fetched directly from the blockchain, reducing potential errors related to incorrect nonce values.

* **New Features**
  * Added clearer error reporting for nonce retrieval failures during transaction processing.

* **Refactor**
  * Simplified nonce handling by standardizing its type to a 64-bit unsigned integer throughout the authorization signing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->