### PR TITLE
Refactor EIP-7702 sender details and improve webhook error handling

### DIFF
--- a/executors/src/eip7702_executor/confirm.rs
+++ b/executors/src/eip7702_executor/confirm.rs
@@ -345,5 +345,3 @@ where
         }
     }
 }
-
-// --- Helper Functions ---

--- a/executors/src/eip7702_executor/send.rs
+++ b/executors/src/eip7702_executor/send.rs
@@ -91,7 +91,7 @@ pub enum Eip7702Sender {
     #[serde(rename_all = "camelCase")]
     SessionKey {
         session_key_address: Address,
-        account_address: Address,
+        eoa_address: Address,
     },
 }
 
@@ -302,7 +302,7 @@ where
         let sender_details = match session_key_target_address {
             Some(target_address) => Eip7702Sender::SessionKey {
                 session_key_address: owner_address,
-                account_address: target_address,
+                eoa_address: target_address,
             },
             None => Eip7702Sender::Owner {
                 eoa_address: owner_address,

--- a/executors/src/webhook/mod.rs
+++ b/executors/src/webhook/mod.rs
@@ -6,6 +6,7 @@ use engine_core::execution_options::WebhookOptions;
 use hex;
 use hmac::{Hmac, Mac};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use twmq::error::TwmqError;
 use twmq::hooks::TransactionContext;
@@ -285,7 +286,7 @@ impl DurableExecution for WebhookJobHandler {
                         body_preview: error_body_preview,
                     };
 
-                    if status.is_server_error() || status.as_u16() == 429 {
+                    if status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS {
                         if job.job.attempts < self.retry_config.max_attempts {
                             let delay_ms = self.retry_config.initial_delay_ms as f64
                                 * self


### PR DESCRIPTION
- Renamed `account_address` to `eoa_address` in the `SessionKey` variant of `Eip7702Sender` for clarity and consistency.
- Updated the webhook error handling logic to use `StatusCode::TOO_MANY_REQUESTS` instead of a numeric comparison for better readability.
- Removed commented-out code in `confirm.rs` to clean up the file.

These changes enhance code clarity and maintainability in the EIP-7702 executor and webhook components.