### PR TITLE
Add EOA metrics tracking and abstraction for degradation and stuck conditions

### DIFF
--- a/executors/src/eoa/store/atomic.rs
+++ b/executors/src/eoa/store/atomic.rs
@@ -68,6 +68,7 @@ pub trait SafeRedisTransaction: Send + Sync {
 pub struct AtomicEoaExecutorStore {
     pub store: EoaExecutorStore,
     pub worker_id: String,
+    pub eoa_metrics: crate::metrics::EoaMetrics,
 }
 
 impl std::ops::Deref for AtomicEoaExecutorStore {
@@ -600,6 +601,7 @@ impl AtomicEoaExecutorStore {
             last_confirmed_nonce,
             keys: &self.keys,
             webhook_queue,
+            eoa_metrics: &self.eoa_metrics,
         })
         .await
     }
@@ -616,6 +618,7 @@ impl AtomicEoaExecutorStore {
             results,
             keys: &self.keys,
             webhook_queue,
+            eoa_metrics: &self.eoa_metrics,
         })
         .await
     }

--- a/executors/src/eoa/store/mod.rs
+++ b/executors/src/eoa/store/mod.rs
@@ -407,6 +407,7 @@ impl EoaExecutorStore {
     pub async fn acquire_eoa_lock_aggressively(
         self,
         worker_id: &str,
+        eoa_metrics: crate::metrics::EoaMetrics,
     ) -> Result<AtomicEoaExecutorStore, TransactionStoreError> {
         let lock_key = self.eoa_lock_key_name();
         let mut conn = self.redis.clone();
@@ -417,6 +418,7 @@ impl EoaExecutorStore {
             return Ok(AtomicEoaExecutorStore {
                 store: self,
                 worker_id: worker_id.to_string(),
+                eoa_metrics,
             });
         }
         let conflict_worker_id = conn.get::<_, Option<String>>(&lock_key).await?;
@@ -434,6 +436,7 @@ impl EoaExecutorStore {
         Ok(AtomicEoaExecutorStore {
             store: self,
             worker_id: worker_id.to_string(),
+            eoa_metrics,
         })
     }
 

--- a/server/configuration/server_base.yaml
+++ b/server/configuration/server_base.yaml
@@ -27,3 +27,7 @@ queue:
   always_poll: false
   max_success: 1000
   max_failed: 10000
+  monitoring:
+    eoa_send_degradation_threshold_seconds: 30
+    eoa_confirmation_degradation_threshold_seconds: 60
+    eoa_stuck_threshold_seconds: 300

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -24,6 +24,27 @@ pub struct QueueConfig {
     pub local_concurrency: usize,
     pub polling_interval_ms: u64,
     pub lease_duration_seconds: u64,
+    
+    #[serde(default)]
+    pub monitoring: MonitoringConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct MonitoringConfig {
+    pub eoa_send_degradation_threshold_seconds: u64,
+    pub eoa_confirmation_degradation_threshold_seconds: u64,
+    pub eoa_stuck_threshold_seconds: u64,
+}
+
+impl Default for MonitoringConfig {
+    fn default() -> Self {
+        Self {
+            eoa_send_degradation_threshold_seconds: 10, // 10 seconds
+            eoa_confirmation_degradation_threshold_seconds: 120, // 2 minutes
+            eoa_stuck_threshold_seconds: 600, // 10 minutes
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/server/src/queue/manager.rs
+++ b/server/src/queue/manager.rs
@@ -207,6 +207,12 @@ impl QueueManager {
             .arc();
 
         // Create EOA executor queue
+        let eoa_metrics = engine_executors::metrics::EoaMetrics::new(
+            queue_config.monitoring.eoa_send_degradation_threshold_seconds,
+            queue_config.monitoring.eoa_confirmation_degradation_threshold_seconds,
+            queue_config.monitoring.eoa_stuck_threshold_seconds,
+        );
+        
         let eoa_executor_handler = EoaExecutorJobHandler {
             chain_service: chain_service.clone(),
             eoa_signer: eoa_signer.clone(),
@@ -216,6 +222,7 @@ impl QueueManager {
             authorization_cache,
             max_inflight: 100,
             max_recycled_nonces: 50,
+            eoa_metrics,
         };
 
         let eoa_executor_queue = Queue::builder()


### PR DESCRIPTION
- Introduced new `EoaMetrics` struct to encapsulate configuration and provide a clean interface for tracking EOA transaction metrics.
- Added metrics for EOA send degradation, confirmation degradation, and stuck conditions, including thresholds for each.
- Updated various components to utilize the new `EoaMetrics` abstraction for recording transaction metrics, enhancing observability and performance monitoring.
- Configured default thresholds in the server configuration for EOA metrics tracking.

These changes improve the robustness of EOA transaction monitoring and facilitate better handling of problematic EOAs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added enhanced EOA monitoring: detects degraded send/confirmation times and stuck accounts, emitting new metrics and warnings.
  * Introduced per-executor metrics handling with thresholds, reporting durations with EOA and chain labels.

* Configuration
  * Added queue monitoring settings for EOA thresholds (send degradation, confirmation degradation, stuck), with sensible defaults and override support in server config.

* Tests
  * Expanded coverage to validate new metrics exposure and threshold-driven behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->