### PR TITLE
Implement delegation contract handling in EIP-7702 executor and bundler client

### DIFF
--- a/core/src/rpc_clients/bundler.rs
+++ b/core/src/rpc_clients/bundler.rs
@@ -88,6 +88,12 @@ pub enum TwGetTransactionHashStatus {
     Success,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TwGetDelegationContractResponse {
+    pub delegation_contract: Address,
+}
+
 impl BundlerClient {
     /// Create a new bundler client with the given transport
     pub fn new(transport: impl IntoBoxTransport) -> Self {
@@ -168,6 +174,11 @@ impl BundlerClient {
         let response: TwGetTransactionHashResponse =
             self.inner.request("tw_getTransactionHash", params).await?;
 
+        Ok(response)
+    }
+
+    pub async fn tw_get_delegation_contract(&self) -> TransportResult<TwGetDelegationContractResponse> {
+        let response: TwGetDelegationContractResponse = self.inner.request("tw_getDelegationContract", ()).await?;
         Ok(response)
     }
 }

--- a/eip7702-core/src/constants.rs
+++ b/eip7702-core/src/constants.rs
@@ -1,8 +1,9 @@
 use alloy::primitives::{Address, address};
 
-/// The minimal account implementation address used for EIP-7702 delegation
-pub const MINIMAL_ACCOUNT_IMPLEMENTATION_ADDRESS: Address =
-    address!("0xD6999651Fc0964B9c6B444307a0ab20534a66560");
+// The minimal account implementation address used for EIP-7702 delegation
+// pub const MINIMAL_ACCOUNT_IMPLEMENTATION_ADDRESS: Address =
+//     address!("0xD6999651Fc0964B9c6B444307a0ab20534a66560");
+// NOTE!: do not hardcode. If needed later, use tw_getDelegationContract
 
 /// EIP-7702 delegation prefix bytes
 pub const EIP_7702_DELEGATION_PREFIX: [u8; 3] = [0xef, 0x01, 0x00];

--- a/eip7702-core/src/transaction.rs
+++ b/eip7702-core/src/transaction.rs
@@ -193,12 +193,13 @@ impl<C: Chain> MinimalAccountTransaction<C> {
         mut self,
         signer: &S,
         credentials: &SigningCredential,
+        delegation_contract: Address,
     ) -> Result<Self, EngineError> {
         if self.account.is_minimal_account().await? {
             return Ok(self);
         }
 
-        let authorization = self.account.sign_authorization(signer, credentials).await?;
+        let authorization = self.account.sign_authorization(signer, credentials, delegation_contract).await?;
         self.authorization = Some(authorization);
         Ok(self)
     }

--- a/executors/src/eip7702_executor/confirm.rs
+++ b/executors/src/eip7702_executor/confirm.rs
@@ -199,7 +199,7 @@ where
             .await
             .map_err(|e| {
                 tracing::error!(
-                    transaction_id = job_data.bundler_transaction_id,
+                    bundler_transaction_id = job_data.bundler_transaction_id,
                     sender_details = ?job_data.sender_details,
                     error = ?e,
                     "Failed to get transaction hash from bundler"

--- a/executors/src/eip7702_executor/delegation_cache.rs
+++ b/executors/src/eip7702_executor/delegation_cache.rs
@@ -1,0 +1,68 @@
+use std::{ops::Deref, sync::Arc};
+
+use alloy::primitives::Address;
+use engine_core::{
+    chain::Chain,
+    error::{AlloyRpcErrorToEngineError, EngineError},
+    rpc_clients::TwGetDelegationContractResponse,
+};
+use moka::future::Cache;
+
+/// Cache key for delegation contract - uses chain_id as the key since each chain has one delegation contract
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+pub struct DelegationContractCacheKey {
+    chain_id: u64,
+}
+
+/// Cache for delegation contract addresses to avoid repeated RPC calls
+#[derive(Clone)]
+pub struct DelegationContractCache {
+    pub inner: moka::future::Cache<DelegationContractCacheKey, Address>,
+}
+
+impl DelegationContractCache {
+    /// Create a new delegation contract cache with the provided moka cache
+    pub fn new(cache: Cache<DelegationContractCacheKey, Address>) -> Self {
+        Self { inner: cache }
+    }
+
+    /// Get the delegation contract address for a chain, fetching it if not cached
+    pub async fn get_delegation_contract<C: Chain>(
+        &self,
+        chain: &C,
+    ) -> Result<Address, EngineError> {
+        let cache_key = DelegationContractCacheKey {
+            chain_id: chain.chain_id(),
+        };
+
+        // Use try_get_with for SWR behavior - this will fetch if not cached or expired
+        let result = self
+            .inner
+            .try_get_with(cache_key, async {
+                tracing::debug!(
+                    chain_id = chain.chain_id(),
+                    "Fetching delegation contract from bundler"
+                );
+
+                let TwGetDelegationContractResponse {
+                    delegation_contract,
+                } = chain
+                    .bundler_client()
+                    .tw_get_delegation_contract()
+                    .await
+                    .map_err(|e| e.to_engine_bundler_error(chain))?;
+
+                tracing::debug!(
+                    chain_id = chain.chain_id(),
+                    delegation_contract = ?delegation_contract,
+                    "Successfully fetched and cached delegation contract"
+                );
+
+                Ok(delegation_contract)
+            })
+            .await
+            .map_err(|e: Arc<EngineError>| e.deref().clone())?;
+
+        Ok(result)
+    }
+}

--- a/executors/src/eip7702_executor/mod.rs
+++ b/executors/src/eip7702_executor/mod.rs
@@ -1,2 +1,3 @@
 pub mod send;
 pub mod confirm;
+pub mod delegation_cache;

--- a/executors/src/eip7702_executor/send.rs
+++ b/executors/src/eip7702_executor/send.rs
@@ -22,7 +22,11 @@ use twmq::{
 };
 
 use crate::{
-    metrics::{record_transaction_queued_to_sent, current_timestamp_ms, calculate_duration_seconds_from_twmq},
+    eip7702_executor::delegation_cache::DelegationContractCache,
+    metrics::{
+        calculate_duration_seconds_from_twmq, current_timestamp_ms,
+        record_transaction_queued_to_sent,
+    },
     transaction_registry::TransactionRegistry,
     webhook::{
         WebhookJobHandler,
@@ -138,6 +142,7 @@ where
     pub webhook_queue: Arc<Queue<WebhookJobHandler>>,
     pub confirm_queue: Arc<Queue<Eip7702ConfirmationHandler<CS>>>,
     pub transaction_registry: Arc<TransactionRegistry>,
+    pub delegation_contract_cache: DelegationContractCache,
 }
 
 impl<CS> ExecutorStage for Eip7702SendHandler<CS>
@@ -216,8 +221,20 @@ where
             None => account.owner_transaction(&job_data.transactions),
         };
 
+        // Get delegation contract from cache
+        let delegation_contract = self
+            .delegation_contract_cache
+            .get_delegation_contract(transactions.account().chain())
+            .await
+            .map_err(|e| Eip7702SendError::DelegationCheckFailed { inner_error: e })
+            .map_err_fail()?;
+
         let transactions = transactions
-            .add_authorization_if_needed(self.eoa_signer.deref(), &job_data.signing_credential)
+            .add_authorization_if_needed(
+                self.eoa_signer.deref(),
+                &job_data.signing_credential,
+                delegation_contract,
+            )
             .await
             .map_err(|e| {
                 let mapped_error = match e {
@@ -281,10 +298,11 @@ where
 
         tracing::debug!(transaction_id = ?transaction_id, "EIP-7702 transaction sent to bundler");
 
-                    // Record metrics: transaction queued to sent
-            let sent_timestamp = current_timestamp_ms();
-            let queued_to_sent_duration = calculate_duration_seconds_from_twmq(job.job.created_at, sent_timestamp);
-            record_transaction_queued_to_sent("eip7702", job_data.chain_id, queued_to_sent_duration);
+        // Record metrics: transaction queued to sent
+        let sent_timestamp = current_timestamp_ms();
+        let queued_to_sent_duration =
+            calculate_duration_seconds_from_twmq(job.job.created_at, sent_timestamp);
+        record_transaction_queued_to_sent("eip7702", job_data.chain_id, queued_to_sent_duration);
 
         let sender_details = match session_key_target_address {
             Some(target_address) => Eip7702Sender::SessionKey {

--- a/executors/src/eip7702_executor/send.rs
+++ b/executors/src/eip7702_executor/send.rs
@@ -227,7 +227,10 @@ where
             .get_delegation_contract(transactions.account().chain())
             .await
             .map_err(|e| Eip7702SendError::DelegationCheckFailed { inner_error: e })
-            .map_err_fail()?;
+            .map_err_nack(
+                Some(Duration::from_secs(2)),
+                twmq::job::RequeuePosition::Last,
+            )?;
 
         let transactions = transactions
             .add_authorization_if_needed(

--- a/executors/src/eoa/worker/mod.rs
+++ b/executors/src/eoa/worker/mod.rs
@@ -479,7 +479,6 @@ impl<C: Chain> EoaExecutorWorker<C> {
     /// This method ensures the health data is always available for the worker
     async fn get_eoa_health(&self) -> Result<EoaHealth, EoaExecutorWorkerError> {
         let store_health = self.store.get_eoa_health().await?;
-        let now = chrono::Utc::now().timestamp_millis().max(0) as u64;
 
         match store_health {
             Some(health) => Ok(health),
@@ -499,6 +498,8 @@ impl<C: Chain> EoaExecutorWorker<C> {
                             inner_error: engine_error,
                         }
                     })?;
+
+                let now = current_timestamp_ms();
 
                 let health = EoaHealth {
                     balance,


### PR DESCRIPTION
7702 Changes:
- Added `TwGetDelegationContractResponse` struct to encapsulate the delegation contract address.
- Introduced `tw_get_delegation_contract` method in `BundlerClient` to fetch the delegation contract.
- Updated transaction signing methods in `DelegatedAccount` and `MinimalAccountTransaction` to accept delegation contract as a parameter.
- Created a `DelegationContractCache` for efficient retrieval of delegation contracts in the executor.

EOA Changes:
- do not send gas bump transaction if out of funds

Monitoring Changes:
- record "out_of_funds" as boolean field on stuck eoas metric

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Network-discovered delegation contract and new RPC to fetch it (replaces hardcoded address).
  - Safer batch popping with per-batch identifiers to reduce lease collisions.

- Performance
  - Per-chain caching of delegation contract reduces network calls and speeds EIP‑7702 flows.

- Reliability
  - Skip gas-bump attempts when accounts lack funds to avoid unnecessary retries.
  - Improved retry/backoff when bundler transaction hash fetches fail.

- Metrics
  - Stuck EOA metric adds an “out_of_funds” label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->