### PR TITLE
Reduce nack durations in EIP-7702 executor and EOA worker error handling

### DIFF
--- a/executors/src/eip7702_executor/confirm.rs
+++ b/executors/src/eip7702_executor/confirm.rs
@@ -214,7 +214,7 @@ where
                     Eip7702ConfirmationError::TransactionHashError {
                         message: e.to_string(),
                     }
-                    .nack(Some(Duration::from_secs(10)), RequeuePosition::Last)
+                    .nack(Some(Duration::from_secs(2)), RequeuePosition::Last)
                 }
             })?;
 
@@ -232,7 +232,7 @@ where
                 return Err(Eip7702ConfirmationError::TransactionHashError {
                     message: "Transaction not yet confirmed".to_string(),
                 })
-                .map_err_nack(Some(Duration::from_secs(2)), RequeuePosition::Last);
+                .map_err_nack(Some(Duration::from_secs(1)), RequeuePosition::Last);
             }
         };
 
@@ -253,7 +253,7 @@ where
                     message: format!("Failed to get transaction receipt: {e}"),
                     inner_error: Some(e.to_engine_error(&chain)),
                 }
-                .nack(Some(Duration::from_secs(5)), RequeuePosition::Last)
+                .nack(Some(Duration::from_secs(1)), RequeuePosition::Last)
             })?;
 
         let receipt = match receipt {
@@ -264,7 +264,7 @@ where
                     message: "Transaction not mined yet".to_string(),
                     transaction_hash,
                 })
-                .map_err_nack(Some(Duration::from_secs(2)), RequeuePosition::Last);
+                .map_err_nack(Some(Duration::from_secs(1)), RequeuePosition::Last);
             }
         };
 

--- a/executors/src/eoa/worker/mod.rs
+++ b/executors/src/eoa/worker/mod.rs
@@ -210,7 +210,7 @@ where
 
         if result.is_work_remaining() {
             Err(EoaExecutorWorkerError::WorkRemaining { result })
-                .map_err_nack(Some(Duration::from_secs(2)), RequeuePosition::Last)
+                .map_err_nack(Some(Duration::from_millis(200)), RequeuePosition::Last)
         } else {
             Ok(result)
         }


### PR DESCRIPTION
- Updated the nack durations for various error handling scenarios in the EIP-7702 executor's confirm module, decreasing wait times from 10 seconds to 2 seconds and from 2 seconds to 1 second.
- Adjusted the nack duration in the EOA worker for work remaining errors from 2 seconds to 200 milliseconds.

These changes aim to improve responsiveness in error handling and reduce overall latency in transaction processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Accelerated transaction confirmation flow by reducing retry backoffs across key steps, leading to faster detection of transaction hashes and receipts and more responsive confirmations.
  * Shortened delays when additional work remains, enabling quicker re-queueing and higher throughput.
  * Overall, users should experience reduced waiting times (from multi‑second pauses to near sub‑second retries in several paths), improving perceived speed without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->