### PR TITLE
Conditional nack duration handling in EoaExecutorWorker

### DIFF
--- a/executors/src/eoa/worker/mod.rs
+++ b/executors/src/eoa/worker/mod.rs
@@ -208,9 +208,15 @@ where
         let job_duration = calculate_duration_seconds(job_start_time, job_end_time);
         record_eoa_job_processing_time(data.chain_id, job_duration);
 
+        let delay = if is_minimal_account {
+            Some(Duration::from_secs(2))
+        } else {
+            Some(Duration::from_millis(200))
+        };
+
         if result.is_work_remaining() {
             Err(EoaExecutorWorkerError::WorkRemaining { result })
-                .map_err_nack(Some(Duration::from_millis(200)), RequeuePosition::Last)
+                .map_err_nack(delay, RequeuePosition::Last)
         } else {
             Ok(result)
         }


### PR DESCRIPTION
- Updated the nack duration for work remaining to be conditional based on account type, setting it to 2 seconds for minimal accounts and 200 milliseconds for others. This change aims to enhance responsiveness in error handling and optimize transaction processing times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Improvements
  * Adjusts task requeue delays based on account type, applying longer backoff for minimal accounts and shorter delays for others.

* Performance
  * Delivers smoother throughput under load with more responsive processing when work remains.

* Reliability
  * Reduces unnecessary retries and churn, easing potential rate-limit pressure through smarter retry spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->