### PR TITLE
Increase gas estimation buffer +50k

### DIFF
--- a/executors/src/eoa/worker/transaction.rs
+++ b/executors/src/eoa/worker/transaction.rs
@@ -310,7 +310,7 @@ impl<C: Chain> EoaExecutorWorker<C> {
         if tx_request.gas.is_none() {
             match self.chain.provider().estimate_gas(tx_request.clone()).await {
                 Ok(gas_limit) => {
-                    tx_request = tx_request.with_gas_limit(gas_limit * 110 / 100); // 10% buffer
+                    tx_request = tx_request.with_gas_limit(gas_limit * 120 / 100 + 50_000); // 20% buffer + 50k overhead
                 }
                 Err(e) => {
                     // Check if this is a revert

--- a/executors/src/eoa/worker/transaction.rs
+++ b/executors/src/eoa/worker/transaction.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
-use alloy::{
+/// Fixed overhead added to gas estimates to account for estimation inaccuracies
+const GAS_ESTIMATION_FIXED_OVERHEAD: u64 = 50_000;
+
+use alloy:{
     consensus::{
         SignableTransaction, Signed, TxEip4844Variant, TxEip4844WithSidecar, TypedTransaction,
     },
@@ -310,7 +313,7 @@ impl<C: Chain> EoaExecutorWorker<C> {
         if tx_request.gas.is_none() {
             match self.chain.provider().estimate_gas(tx_request.clone()).await {
                 Ok(gas_limit) => {
-                    tx_request = tx_request.with_gas_limit(gas_limit * 120 / 100 + 50_000); // 20% buffer + 50k overhead
+                    tx_request = tx_request.with_gas_limit(gas_limit * 120 / 100 + GAS_ESTIMATION_FIXED_OVERHEAD); // 20% buffer + fixed overhead
                 }
                 Err(e) => {
                     // Check if this is a revert


### PR DESCRIPTION
When gas is not provided, increase the safety margin applied to provider's estimate: change from a 10% buffer to a 20% buffer and add a fixed 50,000 gas units overhead. This reduces risk of out-of-gas failures for transactions using estimated limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic gas estimation: transactions now include a larger safety margin (percentage increase plus a fixed buffer) when gas isn't provided, reducing gas-related failures and improving transaction reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->