### PR TITLE
Include ecosystem headers in auth flow

### DIFF
--- a/server/src/http/extractors.rs
+++ b/server/src/http/extractors.rs
@@ -25,6 +25,22 @@ const HEADER_AWS_KMS_ARN: &str = "x-aws-kms-arn";
 const HEADER_AWS_ACCESS_KEY_ID: &str = "x-aws-access-key-id";
 const HEADER_AWS_SECRET_ACCESS_KEY: &str = "x-aws-secret-access-key";
 const HEADER_DIAGNOSTIC_ACCESS_PASSWORD: &str = "x-diagnostic-access-password";
+const HEADER_ECOSYSTEM_ID: &str = "x-ecosystem-id";
+const HEADER_ECOSYSTEM_PARTNER_ID: &str = "x-ecosystem-partner-id";
+
+fn extract_ecosystem_headers(parts: &Parts) -> (Option<String>, Option<String>) {
+    let ecosystem_id = parts
+        .headers
+        .get(HEADER_ECOSYSTEM_ID)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    let ecosystem_partner_id = parts
+        .headers
+        .get(HEADER_ECOSYSTEM_PARTNER_ID)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    (ecosystem_id, ecosystem_partner_id)
+}
 
 /// Extractor for RPC credentials from headers
 #[derive(OperationIo)]
@@ -70,10 +86,14 @@ where
                 })
             })?;
 
+        let (ecosystem_id, ecosystem_partner_id) = extract_ecosystem_headers(parts);
+
         Ok(RpcCredentialsExtractor(RpcCredentials::Thirdweb(
             ThirdwebAuth::ClientIdServiceKey(thirdweb_core::auth::ThirdwebClientIdAndServiceKey {
                 client_id: client_id.to_string(),
                 service_key: service_key.to_string(),
+                ecosystem_id,
+                ecosystem_partner_id,
             }),
         )))
     }
@@ -231,10 +251,14 @@ impl SigningCredentialsExtractor {
                     })
                 })?;
 
+            let (ecosystem_id, ecosystem_partner_id) = extract_ecosystem_headers(parts);
+
             let thirdweb_auth = ThirdwebAuth::ClientIdServiceKey(
                 thirdweb_core::auth::ThirdwebClientIdAndServiceKey {
                     client_id: client_id.to_string(),
                     service_key: service_key.to_string(),
+                    ecosystem_id,
+                    ecosystem_partner_id,
                 },
             );
 

--- a/thirdweb-core/src/auth.rs
+++ b/thirdweb-core/src/auth.rs
@@ -7,6 +7,10 @@ use crate::error::ThirdwebError;
 pub struct ThirdwebClientIdAndServiceKey {
     pub client_id: String,
     pub service_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ecosystem_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ecosystem_partner_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -30,6 +34,21 @@ impl ThirdwebAuth {
                     HeaderValue::from_str(&creds.service_key)
                         .map_err(|_| ThirdwebError::header_value(creds.client_id.clone()))?,
                 );
+                if let Some(ecosystem_id) = &creds.ecosystem_id {
+                    headers.insert(
+                        "x-ecosystem-id",
+                        HeaderValue::from_str(ecosystem_id)
+                            .map_err(|_| ThirdwebError::header_value(ecosystem_id.clone()))?,
+                    );
+                }
+                if let Some(ecosystem_partner_id) = &creds.ecosystem_partner_id {
+                    headers.insert(
+                        "x-ecosystem-partner-id",
+                        HeaderValue::from_str(ecosystem_partner_id).map_err(|_| {
+                            ThirdwebError::header_value(ecosystem_partner_id.clone())
+                        })?,
+                    );
+                }
                 Ok(headers)
             }
             ThirdwebAuth::SecretKey(secret_key) => {


### PR DESCRIPTION
Add support for propagating ecosystem identifiers through the auth flow. Introduce constants and a helper (extract_ecosystem_headers) to read x-ecosystem-id and x-ecosystem-partner-id from request headers in server extractors, and pass them into ThirdwebClientIdAndServiceKey. Extend ThirdwebClientIdAndServiceKey with optional ecosystem_id and ecosystem_partner_id (with serde defaults), and emit these headers when building request headers in ThirdwebAuth::ClientIdServiceKey. This preserves backward compatibility while allowing ecosystem metadata to be forwarded with auth credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for optional ecosystem and ecosystem partner identifier headers in request authentication. These identifiers are now extracted and included in credential management for improved ecosystem tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->