### PR TITLE
Release stale deployment locks and add TTL

### DIFF
--- a/aa-core/src/userop/deployment.rs
+++ b/aa-core/src/userop/deployment.rs
@@ -42,6 +42,15 @@ pub trait DeploymentLock: Send + Sync {
         chain_id: u64,
         account_address: &Address,
     ) -> impl Future<Output = Result<bool, EngineError>> + Send;
+
+    /// Release a deployment lock only if it still holds the given `lock_id`.
+    /// Atomic compare-and-delete; returns true if a matching lock was removed.
+    fn release_lock_if_owner(
+        &self,
+        chain_id: u64,
+        account_address: &Address,
+        lock_id: &str,
+    ) -> impl Future<Output = Result<bool, EngineError>> + Send;
 }
 
 pub enum DeploymentStatus {
@@ -106,8 +115,11 @@ where
                 }
 
                 // Stale lock, not deployed: previous holder died without releasing.
-                // Reclaim it so the caller can retry.
-                self.lock.release_lock(chain_id, account_address).await?;
+                // Reclaim only the lock we observed, so we don't delete a lock that
+                // another worker acquired while we were checking chain state.
+                self.lock
+                    .release_lock_if_owner(chain_id, account_address, &lock_id)
+                    .await?;
                 return Ok(DeploymentStatus::NotDeployed);
             }
 

--- a/aa-core/src/userop/deployment.rs
+++ b/aa-core/src/userop/deployment.rs
@@ -104,9 +104,13 @@ where
                 if is_deployed {
                     return Ok(DeploymentStatus::Deployed);
                 }
+
+                // Stale lock, not deployed: previous holder died without releasing.
+                // Reclaim it so the caller can retry.
+                self.lock.release_lock(chain_id, account_address).await?;
+                return Ok(DeploymentStatus::NotDeployed);
             }
 
-            // Either fresh lock or stale but not deployed
             return Ok(DeploymentStatus::BeingDeployed {
                 stale: is_stale,
                 lock_id,

--- a/executors/src/external_bundler/deployment.rs
+++ b/executors/src/external_bundler/deployment.rs
@@ -7,12 +7,16 @@ use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use twmq::{
     error::TwmqError,
-    redis::{AsyncCommands, Pipeline, aio::ConnectionManager},
+    redis::{AsyncCommands, Pipeline, SetExpiry, SetOptions, aio::ConnectionManager},
 };
 use uuid::Uuid;
 
 const CACHE_PREFIX: &str = "deployment_cache";
 const LOCK_PREFIX: &str = "deployment_lock";
+
+/// Fallback TTL so a lock that's never explicitly released (e.g. worker crash)
+/// can't block the account forever.
+const LOCK_TTL_SECONDS: u64 = 300;
 
 #[derive(Clone)]
 pub struct RedisDeploymentCache {
@@ -165,9 +169,13 @@ impl DeploymentLock for RedisDeploymentLock {
                 message: format!("Serialization failed: {e}"),
             })?;
 
-        // Use SET NX EX for atomic acquire
+        // SET NX EX: atomic acquire with a fallback expiry.
+        let opts = SetOptions::default()
+            .conditional_set(twmq::redis::ExistenceCheck::NX)
+            .with_expiration(SetExpiry::EX(LOCK_TTL_SECONDS));
+
         let result: Option<String> =
-            conn.set_nx(&key, &lock_data_str)
+            conn.set_options(&key, &lock_data_str, opts)
                 .await
                 .map_err(|e| EngineError::InternalError {
                     message: format!("Lock acquire failed: {e}"),

--- a/executors/src/external_bundler/deployment.rs
+++ b/executors/src/external_bundler/deployment.rs
@@ -220,4 +220,38 @@ impl DeploymentLock for RedisDeploymentLock {
 
         Ok(deleted > 0)
     }
+
+    async fn release_lock_if_owner(
+        &self,
+        chain_id: u64,
+        account_address: &Address,
+        lock_id: &str,
+    ) -> Result<bool, EngineError> {
+        let mut conn = self.conn().clone();
+        let key = self.lock_key(chain_id, account_address);
+
+        // Atomic compare-and-delete: only DEL if the stored lock's lock_id matches.
+        let script = twmq::redis::Script::new(
+            r#"
+            local v = redis.call('GET', KEYS[1])
+            if not v then return 0 end
+            local ok, data = pcall(cjson.decode, v)
+            if ok and data.lock_id == ARGV[1] then
+                return redis.call('DEL', KEYS[1])
+            end
+            return 0
+            "#,
+        );
+
+        let deleted: i64 = script
+            .key(&key)
+            .arg(lock_id)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(|e| EngineError::InternalError {
+                message: format!("Failed to release lock for account {account_address}: {e}"),
+            })?;
+
+        Ok(deleted > 0)
+    }
 }


### PR DESCRIPTION
Reclaim stale deployment locks and prevent permanent lockout: aa-core now releases a stale lock when the account isn't deployed and returns NotDeployed so callers can retry. The external bundler uses Redis SET with NX + EX via SetOptions/SetExpiry and adds a 300s fallback LOCK_TTL_SECONDS to ensure locks auto-expire if a holder dies. This avoids stuck deployments and makes lock acquisition atomic with an expiry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment status detection improved: stale locks trigger a re-check of chain state and are safely reclaimed when the account is not deployed, preventing incorrect "deployed" reporting.
  * Locks now auto-expire after a fixed TTL and include ownership-protected release to avoid indefinite persistence and race conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thirdweb-dev/engine-core/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->